### PR TITLE
la inn docstrings til fetch_data_frost,  fetch_data_nasa og clean_data

### DIFF
--- a/src/clean_data.py
+++ b/src/clean_data.py
@@ -5,13 +5,39 @@ import os
 
 def clean_and_merge_weather_data(frost_path, nasa_path):
     """
-    Leser, renser og kombinerer værdata fra FROST og NASA.
-    - Fjerner tidssoner og formaterer datoer
-    - Fyller inn manglende verdier med median
-    - Fjerner uregelmessige verdier
-    - Standardiserer kolonnenavn
-    - Sorterer data etter dato
-    - Kjører SQL-analyse for aggregert daglig værdata
+    Leser, renser og kombinerer værdata fra FROST og NASA, og returnerer et renset og aggregert datasett.
+
+    Denne funksjonen utfører følgende steg:
+    1. Leser inn rådata fra CSV-filer produsert av FROST og NASA.
+    2. Simulerer datakvalitetsproblemer for å teste renselogikk (kun for utviklingsformål).
+    3. Rensker data:
+        - Konverterer og validerer datoer
+        - Fyller manglende verdier med median
+        - Fjerner urealistiske verdier (f.eks. ekstrem temperatur, luftfuktighet over 100 %)
+    4. Slår sammen de to datasettene på dato.
+    5. Beregner en enkel komfortindeks basert på temperatur og luftfuktighet.
+    6. Standardiserer kolonnenavn for SQL-analyse.
+    7. Kjører en SQL-spørring via pandasql for å beregne daglige gjennomsnittsverdier.
+    8. Lagrer det rensede datasettet til `data/clean/merged_data.csv`.
+
+    Parametere:
+        frost_path (str): Filsti til FROST-data i CSV-format.
+        nasa_path (str): Filsti til NASA-data i CSV-format.
+
+    Returnerer:
+        tuple[pd.DataFrame, pd.DataFrame]: 
+            - Det fullstendig rensede og sammenslåtte datasettet.
+            - Et datasett med daglig aggregerte verdier.
+
+    Unntak:
+        FileNotFoundError: Hvis en av inputfilene ikke finnes.
+        ValueError: Hvis en av inputfilene er tom.
+
+    Avhengigheter:
+        - pandas
+        - numpy
+        - pandasql
+        - os
     """
 
     print(" Leser inn data fra CSV...")
@@ -120,7 +146,7 @@ def clean_and_merge_weather_data(frost_path, nasa_path):
     return merged_df, daily_avg
 
 
-# 🔹 Kjør funksjonen dersom scriptet kjøres direkte
+# Kjør funksjonen dersom scriptet kjøres direkte
 if __name__ == "__main__":
     frost_file = "data/raw/frost_data.csv"
     nasa_file = "data/raw/nasa_extended_data.csv"

--- a/src/fetch_data_frost.py
+++ b/src/fetch_data_frost.py
@@ -4,6 +4,34 @@ from collections import defaultdict
 import os
 
 def fetch_data_frost():
+
+    """
+    Henter og lagrer daglige værdata fra Frost API for en gitt periode.
+
+    Funksjonen bruker MET Norway sitt Frost API for å hente observasjoner for værstasjonen SN18700.
+    Den samler inn daglige gjennomsnitt for temperatur, vindhastighet, vindretning, relativ luftfuktighet,
+    lufttrykk ved havnivå, og daglig nedbør. Dataene aggregeres etter dato og lagres som en CSV-fil
+    i katalogen `data/raw/frost_data.csv`.
+
+    Bruker autentisering via en klient-ID og sender en GET-forespørsel til Frost API.
+    Dersom forespørselen lykkes, struktureres og lagres dataene. Hvis ikke, skrives en feilmelding ut.
+
+    CSV-filen inneholder følgende kolonner:
+    - Date
+    - Temperature
+    - Wind Speed
+    - Wind Direction
+    - Precipitation
+    - Humidity
+    - Pressure
+
+    Avhengigheter:
+        - requests
+        - csv
+        - collections.defaultdict
+        - os
+    """
+      
     client_id = "c533be15-1b26-4225-bf7d-cc5e5c81beb5"
     endpoint = "https://frost.met.no/observations/v0.jsonld"
 

--- a/src/fetch_data_nasa.py
+++ b/src/fetch_data_nasa.py
@@ -2,6 +2,27 @@ import requests
 import pandas as pd
 
 def fetch_nasa_data():
+
+    """
+    Henter og lagrer daglige miljødata fra NASA POWER API for Blindern-området.
+
+    Funksjonen sender en GET-forespørsel til NASA POWER sitt API for å hente daglige observasjoner 
+    av følgende parametere:
+        - ALLSKY_SFC_SW_DWN: Solinnstråling ved jordoverflaten (W/m²)
+        - TS: Bakketemperatur (°C)
+        - QV2M: Spesifikk fuktighet 2 meter over bakken (kg/kg)
+        - PS: Overflatetrykk (Pa)
+
+    Koordinatene som brukes er 59.943°N, 10.718°E (Oslo-Blindern), for perioden 1. januar 2020 til 30. januar 2025.
+
+    Hvis forespørselen er vellykket og dataene finnes i responsen, konverteres dataene til en Pandas DataFrame,
+    datoene parses, og resultatet lagres som en CSV-fil i `data/raw/nasa_extended_data.csv`.
+
+    Avhengigheter:
+        - requests
+        - pandas
+    """
+
     # NASA POWER API-endepunkt
     url = "https://power.larc.nasa.gov/api/temporal/daily/point"
 


### PR DESCRIPTION
I denne branchen er det lagt til og forbedret docstrings for tre sentrale funksjoner i prosjektet: fetch_data_frost, fetch_nasa_data og clean_and_merge_weather_data. Hensikten med endringene er å gjøre koden bedre dokumentert og lettere å forstå for både medutviklere og sensor. Docstringsene er skrevet i tråd med PEP 257-standardene og inkluderer informasjon om formål, inputparametere, eventuelle unntak og avhengigheter.